### PR TITLE
Added app.kubernetes.io/component: metrics to better categorize this role as part of the metrics-related functionality. 

### DIFF
--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,12 +1,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: metrics-reader
   labels:
     app.kubernetes.io/name: file-browser-operator
     app.kubernetes.io/managed-by: kustomize
-  name: metrics-reader
+    app.kubernetes.io/component: metrics
+  annotations:
+    description: "Grants read-only access to cluster metrics endpoint"
 rules:
 - nonResourceURLs:
-  - "/metrics"
+    - "/metrics"
   verbs:
-  - get
+    - "get"


### PR DESCRIPTION
Added app.kubernetes.io/component: metrics to better categorize this role as part of the metrics-related functionality. This follows the recommended Kubernetes label structure for clarity and filtering.